### PR TITLE
add glyph ascender

### DIFF
--- a/proto/glyphs.proto
+++ b/proto/glyphs.proto
@@ -17,6 +17,7 @@ message glyph {
     required sint32 left = 5;
     required sint32 top = 6;
     required uint32 advance = 7;
+    optional uint32 ascender = 8;
 }
 
 // Stores fontstack information and a list of faces.

--- a/src/fontnik/glyphs.cpp
+++ b/src/fontnik/glyphs.cpp
@@ -86,6 +86,7 @@ void Glyphs::Range(std::string fontstack,
             mutable_glyph->set_left(glyph.left);
             mutable_glyph->set_top(glyph.top - glyph.ascender);
             mutable_glyph->set_advance(glyph.advance);
+            mutable_glyph->set_ascender(glyph.ascender);
 
             if (glyph.width > 0) {
                 mutable_glyph->set_bitmap(glyph.bitmap);


### PR DESCRIPTION
Adds glyph ascender to protobuf, used to position glyph relative to baseline.