### PR TITLE
multi-os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+- linux
+- osx
 language: cpp
 compiler:
 - gcc

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "queue-async": "1.0.x",
-    "node-pre-gyp": "0.5.15",
+    "node-pre-gyp": "0.5.23",
     "nan": "~1.2.0",
     "minimist": "~0.2.0"
   },


### PR DESCRIPTION
Thanks to @springmeyer's prior art in https://github.com/mapbox/mapbox-gl-native/pull/307.

Is there anything useful that could be pulled in from https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/setup_travis.sh or cleaned up in https://github.com/mapbox/node-fontnik/blob/multi-os/.travis.yml?

Assuming this will let us kill off https://github.com/mapbox/node-fontnik/tree/travis-osx branch.

http://docs.travis-ci.com/user/multi-os/
