### PR TITLE
Fix build-glyphs example

### DIFF
--- a/bin/build-glyphs
+++ b/bin/build-glyphs
@@ -10,7 +10,7 @@ if (process.argv.length !== 4) {
     console.log('  build-glyphs <fontstack> <output dir>');
     console.log('');
     console.log('Example:');
-    console.log('  build-glyphs "Open Sans Regular, Arial Unicode MS Regular" glyphs/');
+    console.log('  build-glyphs "Open Sans Regular" glyphs/');
     process.exit(1);
 }
 


### PR DESCRIPTION
Fix build-glyphs example to use the font name of Open Sans Regular that can be found in the node-fontnik project
