### PR TITLE
Fix compile error against boost geometry  >= 1.56 on OS X

### DIFF
--- a/vendor/fontnik/include/fontnik/face.hpp
+++ b/vendor/fontnik/include/fontnik/face.hpp
@@ -27,6 +27,8 @@
 #include <mapnik/text/glyph_info.hpp>
 
 // boost
+// undef B0 to workaround https://svn.boost.org/trac/boost/ticket/10467
+#undef B0
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>


### PR DESCRIPTION
Refs https://svn.boost.org/trac/boost/ticket/10467

Avoids error like:

```
In file included from ../vendor/fontnik/src/glyphs.cpp:26:
In file included from ../vendor/mapnik/include/mapnik/text/face_set.hpp:31:
In file included from ../vendor/fontnik/include/fontnik/face.hpp:30:
In file included from /usr/local/include/boost/geometry.hpp:17:
In file included from /usr/local/include/boost/geometry/geometry.hpp:51:
In file included from /usr/local/include/boost/geometry/algorithms/comparable_distance.hpp:22:
/usr/local/include/boost/geometry/algorithms/detail/comparable_distance/interface.hpp:236:5: error: expected unqualified-id
/usr/local/include/boost/variant/variant_fwd.hpp:164:5: note: expanded from macro 'BOOST_VARIANT_ENUM_PARAMS'
    BOOST_PP_ENUM_PARAMS(BOOST_VARIANT_LIMIT_TYPES, param)
    ^
/usr/local/include/boost/preprocessor/repetition/enum_params.hpp:24:71: note: expanded from macro 'BOOST_PP_ENUM_PARAMS'
#    define BOOST_PP_ENUM_PARAMS(count, param) BOOST_PP_REPEAT(count, BOOST_PP_ENUM_PARAMS_M, param)
                                                                      ^
/usr/local/include/boost/preprocessor/repetition/repeat.hpp:38:60: note: expanded from macro 'BOOST_PP_REPEAT_1'
# define BOOST_PP_REPEAT_1(c, m, d) BOOST_PP_REPEAT_1_I(c, m, d)
                                                           ^
note: (skipping 24 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/usr/local/include/boost/preprocessor/control/iif.hpp:25:60: note: expanded from macro 'BOOST_PP_IIF_I'
#    define BOOST_PP_IIF_I(bit, t, f) BOOST_PP_IIF_ ## bit(t, f)
                                                           ^
/usr/local/include/boost/preprocessor/control/iif.hpp:32:31: note: expanded from macro 'BOOST_PP_IIF_1'
# define BOOST_PP_IIF_1(t, f) t
                              ^
/usr/local/include/boost/preprocessor/punctuation/comma.hpp:19:27: note: expanded from macro 'BOOST_PP_COMMA'
# define BOOST_PP_COMMA() ,
                          ^
```
