### PR TITLE
[don't merge] Return family/face names

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,16 +33,12 @@ Create a new Glyphs object.
 
 ### `glyphs.codepoints(face: string): Object`
 
-Gets an object with font metadata and unicode points where this font face[s] has
-coverage. Supports composited fonts. Returns an object with keys:
+Gets an object with font metadata and an array of numbers corresponding to
+unicode points where this font face[s] has coverage. Supports composited
+fonts. Returns an object with keys:
 
 * `faces: array[ Object{ face_name: string, style_name: string } ]`
 * `codepoints: array[number]`
-
-### `glyphs.codepoints(face: string): Array<number>`
-
-Get an array of numbers corresponding to unicode points where this font face
-has coverage.
 
 ### `glyphs.range(face: string, range: string, chars: Array<number>, callback: function)`
 

--- a/API.md
+++ b/API.md
@@ -31,6 +31,14 @@ Return an array of supported font faces, as strings.
 
 Create a new Glyphs object.
 
+### `glyphs.codepoints(face: string): Object`
+
+Gets an object with font metadata and unicode points where this font face[s] has
+coverage. Supports composited fonts. Returns an object with keys:
+
+* `faces: array[ Object{ face_name: string, style_name: string } ]`
+* `codepoints: array[number]`
+
 ### `glyphs.codepoints(face: string): Array<number>`
 
 Get an array of numbers corresponding to unicode points where this font face

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+* `.codepoints()` now returns an object with `faces` array of family_name and
+style_name metadata, and `codepoints` array of unicode point coverage.
+
 # 0.2.3
 
 * Calling .codepoints() on an invalid font will throw a JavaScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontnik",
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "A library that delivers a range of glyphs rendered as SDFs (signed distance fields) in a protobuf.",
   "keywords": [
     "font",

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -5,6 +5,9 @@
 #include <node_buffer.h>
 #include <nan.h>
 
+// DELETE
+#include <iostream>
+
 namespace node_fontnik
 {
 
@@ -148,12 +151,21 @@ NAN_METHOD(Glyphs::Codepoints) {
     std::string from = std::string(*param1);
     try {
         std::vector<int> points = fontnik::Glyphs::Codepoints(from);
+        std::map<std::string, std::string> metadata = fontnik::Glyphs::FontInfo(from);
 
-        v8::Handle<v8::Array> result = v8::Array::New(points.size());
+        v8::Handle<v8::Object> result = v8::Object::New();
+
+        result->Set(NanNew<v8::String>("family_name"), NanNew<v8::String>(metadata["family_name"].c_str()));
+        result->Set(NanNew<v8::String>("style_name"), NanNew<v8::String>(metadata["style_name"].c_str()));
+
+        v8::Handle<v8::Array> resultPoints = v8::Array::New(points.size());
 
         for (size_t i = 0; i < points.size(); i++) {
-            result->Set(i, NanNew<v8::Number>(points[i]));
+            resultPoints->Set(i, NanNew<v8::Number>(points[i]));
         }
+
+        result->Set(NanNew<v8::String>("codepoints"), resultPoints);
+
         NanReturnValue(result);
     } catch (std::exception const& ex) {
         return NanThrowTypeError(ex.what());

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -5,9 +5,6 @@
 #include <node_buffer.h>
 #include <nan.h>
 
-// DELETE
-#include <iostream>
-
 namespace node_fontnik
 {
 

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -148,12 +148,17 @@ NAN_METHOD(Glyphs::Codepoints) {
     std::string from = std::string(*param1);
     try {
         std::vector<int> points = fontnik::Glyphs::Codepoints(from);
-        std::map<std::string, std::string> metadata = fontnik::Glyphs::FontInfo(from);
+        std::vector<std::map<std::string, std::string>> metadata = fontnik::Glyphs::FontInfo(from);
 
-        v8::Handle<v8::Object> result = v8::Object::New();
+        v8::Handle<v8::Array> resultFaces = v8::Array::New(metadata.size());
 
-        result->Set(NanNew<v8::String>("family_name"), NanNew<v8::String>(metadata["family_name"].c_str()));
-        result->Set(NanNew<v8::String>("style_name"), NanNew<v8::String>(metadata["style_name"].c_str()));
+        for (size_t i = 0; i < metadata.size(); i++) {
+            std::map<std::string, std::string> facedata = metadata[i];
+            v8::Handle<v8::Object> face = v8::Object::New();
+            face->Set(NanNew<v8::String>("family_name"), NanNew<v8::String>(facedata["family_name"].c_str()));
+            face->Set(NanNew<v8::String>("style_name"), NanNew<v8::String>(facedata["style_name"].c_str()));
+            resultFaces->Set(i, face);
+        }
 
         v8::Handle<v8::Array> resultPoints = v8::Array::New(points.size());
 
@@ -161,6 +166,9 @@ NAN_METHOD(Glyphs::Codepoints) {
             resultPoints->Set(i, NanNew<v8::Number>(points[i]));
         }
 
+        v8::Handle<v8::Object> result = v8::Object::New();
+
+        result->Set(NanNew<v8::String>("faces"), resultFaces);
         result->Set(NanNew<v8::String>("codepoints"), resultPoints);
 
         NanReturnValue(result);

--- a/test/test.js
+++ b/test/test.js
@@ -158,20 +158,26 @@ describe('codepoints', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Open Sans Regular');
         assert.equal(cp.codepoints.length, 882);
-        assert.equal(cp.family_name, 'Open Sans');
-        assert.equal(cp.style_name, 'Regular');
+        assert.equal(cp.faces.length, 1);
+        assert.equal(cp.faces[0].family_name, 'Open Sans');
+        assert.equal(cp.faces[0].style_name, 'Regular');
     });
     it('basic scanning: fira sans', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Fira Sans Medium');
         assert.equal(cp.codepoints.length, 789);
-        assert.equal(cp.family_name, 'Fira Sans');
-        assert.equal(cp.style_name, 'Medium');
+        assert.equal(cp.faces[0].family_name, 'Fira Sans');
+        assert.equal(cp.faces[0].style_name, 'Medium');
     });
     it('basic scanning: fira sans + open sans', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Fira Sans Medium, Open Sans Regular');
         assert.equal(cp.codepoints.length, 1021);
+        assert.equal(cp.faces.length, 2);
+        assert.equal(cp.faces[0].family_name, 'Fira Sans');
+        assert.equal(cp.faces[0].style_name, 'Medium');
+        assert.equal(cp.faces[1].family_name, 'Open Sans');
+        assert.equal(cp.faces[1].style_name, 'Regular');
     });
     it('invalid font face', function() {
         var glyphs = new fontnik.Glyphs();

--- a/test/test.js
+++ b/test/test.js
@@ -157,17 +157,21 @@ describe('codepoints', function() {
     it('basic scanning: open sans', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Open Sans Regular');
-        assert.equal(cp.length, 882);
+        assert.equal(cp.codepoints.length, 882);
+        assert.equal(cp.family_name, 'Open Sans');
+        assert.equal(cp.style_name, 'Regular');
     });
     it('basic scanning: fira sans', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Fira Sans Medium');
-        assert.equal(cp.length, 789);
+        assert.equal(cp.codepoints.length, 789);
+        assert.equal(cp.family_name, 'Fira Sans');
+        assert.equal(cp.style_name, 'Medium');
     });
     it('basic scanning: fira sans + open sans', function() {
         var glyphs = new fontnik.Glyphs();
         var cp = glyphs.codepoints('Fira Sans Medium, Open Sans Regular');
-        assert.equal(cp.length, 1021);
+        assert.equal(cp.codepoints.length, 1021);
     });
     it('invalid font face', function() {
         var glyphs = new fontnik.Glyphs();

--- a/vendor/fontnik/include/fontnik/glyphs.hpp
+++ b/vendor/fontnik/include/fontnik/glyphs.hpp
@@ -42,7 +42,8 @@ public:
                std::string range,
                std::vector<std::uint32_t> chars);
 
-    static std::vector<int> Codepoints(std::string fontstack);
+    static std::vector<int> Codepoints(std::string const& fontstack);
+    static std::map<std::string, std::string> FontInfo(std::string const& fontstack);
 
     static std::string Trim(std::string str, std::string whitespace);
 

--- a/vendor/fontnik/include/fontnik/glyphs.hpp
+++ b/vendor/fontnik/include/fontnik/glyphs.hpp
@@ -43,7 +43,7 @@ public:
                std::vector<std::uint32_t> chars);
 
     static std::vector<int> Codepoints(std::string const& fontstack);
-    static std::map<std::string, std::string> FontInfo(std::string const& fontstack);
+    static std::vector<std::map<std::string, std::string>> FontInfo(std::string const& fontstack);
 
     static std::string Trim(std::string str, std::string whitespace);
 

--- a/vendor/fontnik/src/glyphs.cpp
+++ b/vendor/fontnik/src/glyphs.cpp
@@ -119,7 +119,7 @@ void Glyphs::Range(std::string fontstack,
     }
 }
 
-std::vector<int> Glyphs::Codepoints(std::string fontstack)
+std::vector<int> Glyphs::Codepoints(std::string const& fontstack)
 {
     std::vector<int> points;
     mapnik_fontnik::freetype_engine font_engine_;
@@ -155,6 +155,34 @@ std::vector<int> Glyphs::Codepoints(std::string fontstack)
     points.erase(last, points.end());
 
     return points;
+}
+
+std::map<std::string, std::string> Glyphs::FontInfo(std::string const& fontstack)
+{
+    std::map<std::string, std::string> metadata;
+    mapnik_fontnik::freetype_engine font_engine_;
+    mapnik_fontnik::face_manager_freetype font_manager(font_engine_);
+
+    mapnik_fontnik::font_set font_set(fontstack);
+    std::stringstream stream(fontstack);
+    std::string face_name;
+
+    while (std::getline(stream, face_name, ',')) {
+        font_set.add_face_name(Trim(face_name, " \t"));
+    }
+
+    mapnik_fontnik::face_set_ptr face_set;
+
+    face_set = font_manager.get_face_set(font_set);
+    for (auto const& face : *face_set) {
+        FT_Face ft_face = face->get_face();
+        FT_String* family_name = ft_face->family_name;
+        FT_String* style_name = ft_face->style_name;
+        metadata.emplace("family_name", family_name);
+        metadata.emplace("style_name", style_name);
+    }
+
+    return metadata;
 }
 
 std::string Glyphs::Trim(std::string str, std::string whitespace)

--- a/vendor/fontnik/src/glyphs.cpp
+++ b/vendor/fontnik/src/glyphs.cpp
@@ -157,9 +157,9 @@ std::vector<int> Glyphs::Codepoints(std::string const& fontstack)
     return points;
 }
 
-std::map<std::string, std::string> Glyphs::FontInfo(std::string const& fontstack)
+std::vector<std::map<std::string, std::string>> Glyphs::FontInfo(std::string const& fontstack)
 {
-    std::map<std::string, std::string> metadata;
+    std::vector<std::map<std::string, std::string>> faces;
     mapnik_fontnik::freetype_engine font_engine_;
     mapnik_fontnik::face_manager_freetype font_manager(font_engine_);
 
@@ -175,14 +175,16 @@ std::map<std::string, std::string> Glyphs::FontInfo(std::string const& fontstack
 
     face_set = font_manager.get_face_set(font_set);
     for (auto const& face : *face_set) {
+        std::map<std::string, std::string> metadata;
         FT_Face ft_face = face->get_face();
         FT_String* family_name = ft_face->family_name;
         FT_String* style_name = ft_face->style_name;
         metadata.emplace("family_name", family_name);
         metadata.emplace("style_name", style_name);
+        faces.push_back(metadata);
     }
 
-    return metadata;
+    return faces;
 }
 
 std::string Glyphs::Trim(std::string str, std::string whitespace)


### PR DESCRIPTION
Closes #69.

After discussing with @mikemorris I implemented it so that, at least initially, [`glyphs.codepoints(facename)`](https://github.com/mapbox/node-fontnik/blob/master/API.md#glyphscodepointsface-string-arraynumber) returns an object wrapping the old `codepoints`, i.e.
``` json
{
  "family_name": "Open Sans",
  "style_name": "Regular",
  "codepoints": [0,2,3,…,127760] 
}
```

Questions:
* `codepoints` can composite fontstacks. But `family_name` addresses a non-compositing use case. Should I break this out entirely into a separate method that just returns family/name metadata, and leave `codepoints` as-is? Or do we even need to still composite codepoint stacks in fontnik? (Not using in [glyph-pbf-composite](https://github.com/mapbox/glyph-pbf-composite/blob/master/index.js), which we'll use in the API.)
* While I'm here, is there [anything else useful](http://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#FT_FaceRec) we want from FreeType?

To do:
- [x] address compositing names question, and in doing so fix the vendor/glyphs method's currently-unused iterating
- [ ] depending on above, rename `glyphs.codepoints()` — accessing `codepoints(face).codepoints` is weird
- [ ] depending on above, major or minor semver
- [x] docs
- [ ] binary

cc @tmcw @yhahn 