### PR TITLE
Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: cpp
 
-os:
-- linux
-- osx
-
-compiler:
-- clang
-- gcc
+matrix:
+  include:
+     # Coverage
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="0.10" COVERAGE=true
+     # Linux
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="0.10"
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="0.12"
+     # OS X
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="0.10"
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="0.12"
 
 env:
-  matrix:
-  - NODE_VERSION="0.10.37"
-  - NODE_VERSION="0.12.0"
   global:
-  - BUILD: '/tmp/fontnik-build'
-  - PKG_CONFIG_PATH: '/tmp/fontnik-build/lib/pkgconfig'
-  - secure: "XV0lekmfgT+D9t0ZTIU+UJF6g+p3cBQMO6T6C9lkoKTC0YbtLtxSFtBahD/4PjL86DMJgTaf1nBmxqOxbrfkcpJUxnLe3r8u4Z2L/+7+QSACLNktlIfWNSO+33WxKNb4mVw6jMFZIo4ZurF016MXYzLzjpxRELW2oO2STUs2m44="
-  - secure: "CQNHbxw8yHlAdUVbKokHzHmj7C+duXP3mifWOkZm9GKw4myWsRFhhoSYZmOSkgj9EWfYYkedrqEr9+GaMg9rkVJuO/7jzn6S+M7CFXKJju6MoZEDO6WcFva4M8pw6IFb9q22GcQ+OsE8/i0DwchTokyFkNb3fpwWuwROUPQ/nWg="
+   - JOBS: "8"
+   - BUILD: '/tmp/fontnik-build'
+   - PKG_CONFIG_PATH: '/tmp/fontnik-build/lib/pkgconfig'
+   - secure: "XV0lekmfgT+D9t0ZTIU+UJF6g+p3cBQMO6T6C9lkoKTC0YbtLtxSFtBahD/4PjL86DMJgTaf1nBmxqOxbrfkcpJUxnLe3r8u4Z2L/+7+QSACLNktlIfWNSO+33WxKNb4mVw6jMFZIo4ZurF016MXYzLzjpxRELW2oO2STUs2m44="
+   - secure: "CQNHbxw8yHlAdUVbKokHzHmj7C+duXP3mifWOkZm9GKw4myWsRFhhoSYZmOSkgj9EWfYYkedrqEr9+GaMg9rkVJuO/7jzn6S+M7CFXKJju6MoZEDO6WcFva4M8pw6IFb9q22GcQ+OsE8/i0DwchTokyFkNb3fpwWuwROUPQ/nWg="
 
 before_install:
+ - export COVERAGE=${COVERAGE:-false}
  - export platform=$(uname -s | sed "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/")
  # here we set up the node version on the fly based on the matrix value.
  # This is done manually so that it is easy to flip the 'language' to
@@ -29,15 +41,30 @@ before_install:
  - nvm use $NODE_VERSION
  - node --version
  - npm --version
+ - if [[ ${COVERAGE} == true ]]; then
+      brew update;
+      brew install pyenv;
+      eval "$(pyenv init -)";
+      pyenv install 2.7.6;
+      pyenv global 2.7.6;
+      pyenv rehash;
+      pip install cpp-coveralls;
+      pyenv rehash;
+     fi;
  - export PATH="$BUILD/bin:$PATH"
  - if [[ "$platform" == "linux" ]]; then export CXX=g++-4.8; export CC=gcc-4.8; fi
  - ./deps/travis_build.sh
 
 install:
- - npm install --build-from-source
+ - if [[ ${COVERAGE} == true ]]; then
+    export LDFLAGS="--coverage" && export CXXFLAGS="--coverage" && npm install --build-from-source --debug --clang=1;
+  else
+    npm install --build-from-source --clang=1;
+  fi;
 
 script:
  - npm test
+ - if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude tests --build-root build --gcov-options '\-lp' --exclude doc --exclude build/Release/obj/gen; fi;
 
 after_success:
  - ./deps/travis_publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
 
 script:
  - npm test
- - if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude tests --build-root build --gcov-options '\-lp' --exclude doc --exclude build/Release/obj/gen; fi;
+ - if [[ ${COVERAGE} == true ]]; then cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude doc --exclude build/Release/obj/gen; fi;
 
 after_success:
  - ./deps/travis_publish.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # node-fontnik
 
-[![NPM](https://nodei.co/npm/fontnik.png?compact=true)](https://nodei.co/npm/fontnik/) [![Build Status](https://travis-ci.org/mapbox/node-fontnik.svg?branch=master)](https://travis-ci.org/mapbox/node-fontnik)
+[![NPM](https://nodei.co/npm/fontnik.png?compact=true)](https://nodei.co/npm/fontnik/)
+[![Build Status](https://travis-ci.org/mapbox/node-fontnik.svg?branch=master)](https://travis-ci.org/mapbox/node-fontnik)
+[![Coverage Status](https://coveralls.io/repos/mapbox/node-fontnik/badge.svg?branch=coverage)](https://coveralls.io/r/mapbox/node-fontnik?branch=coverage)
 
 A library that delivers a range of glyphs rendered as SDFs (signed distance fields) in a protocol buffer. We use these encoded glyphs as the basic blocks of font rendering in [Mapbox GL](https://github.com/mapbox/mapbox-gl-js). SDF encoding is superior to traditional fonts for our usecase terms of scaling, rotation, and quickly deriving halos - WebGL doesn't have built-in font rendering, so the decision is between vectorization, which tends to be slow, and SDF generation.
 

--- a/deps/travis_publish.sh
+++ b/deps/travis_publish.sh
@@ -11,7 +11,7 @@ fi
 
 COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
 
-if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"
+if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE" && [[ ${COVERAGE} == false ]];
     then
 
     npm install aws-sdk


### PR DESCRIPTION
@lbud - this enables per-commit code coverage reports over at https://coveralls.io/r/mapbox/node-fontnik for your `overhaul` branch.

Thanks @flippmoke for figuring out the secrets of how to get this working for node c++ addons.