### PR TITLE
fixing bounds for short ranges

### DIFF
--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -270,7 +270,7 @@ void RangeAsync(uv_work_t* req) {
 
     unsigned array_size = baton->end - baton->start;
     baton->chars.reserve(array_size);
-    for (unsigned i=baton->start; i <= array_size; i++) {
+    for (unsigned i=baton->start; i <= baton->end; i++) {
         baton->chars.emplace_back(i);
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,15 @@ describe('range', function() {
         });
     });
 
+    it('shortrange', function(done) {
+        this.timeout(10000);
+        fontnik.range({font: opensans, start: 34, end: 38}, function(err, res) {
+            var vt = new Glyphs(new Protobuf(new Uint8Array(res)));
+            var codes = Object.keys(vt.stacks['Open Sans Regular'].glyphs);
+            assert.deepEqual(codes, [ '34', '35', '36', '37', '38' ]);
+            done();
+        });
+    });
 
     it('range typeerror options', function(done) {
         assert.throws(function() {


### PR DESCRIPTION
- fix short ranges for e.g. `{ start: 34, end: 38 }`
- add a test


might also be worth noting in the docs that `end` is inclusive

see #89 