### PR TITLE
[notready] build/install adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "font-inspect": "./bin/font-inspect"
   },
   "scripts": {
-    "install": ". ./scripts/install_mason.sh && node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --fallback-to-build=false || (. ./scripts/install_mason.sh && node-pre-gyp install --build-from-source)",
     "test": "./node_modules/.bin/tape test/**/*.test.js | ./node_modules/.bin/faucet"
   },
   "binary": {

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -3,8 +3,8 @@
 set -e
 set -o pipefail
 
-git clone https://github.com/creationix/nvm.git ../.nvm
-source ../.nvm/nvm.sh
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.28.0/install.sh | bash
+source ~/.nvm/nvm.sh
 
 nvm install ${NODE_EXE} ${NODE_VERSION}
 


### PR DESCRIPTION
Issues:

- Seeing some failures on travis to build latest release binaries.
- Seeing failure to install node-fontnik when it's a nested dependency.

Fixes in the works:

- **Don't try to install mason unless static binary install fails.** This should cover most cases, but I'm seeing mason still isn't really designed to be installed this way in nested fashion -- if you are going to need a source build of node-fontnik as a nested dep we still won't have you covered yet.
- **Fix OS X builds.** Something about the new nvm (0.29.0+) is failing to install node on OS X. Pinning to v0.28.0 for now.

TODO:

- **Fix node version/abi for v14 builds.** The previous binary builds somehow only pushed out abi v11. Something about the build matrix/nvm is not hooking up properly...

cc @mikemorris