### PR TITLE
Lock queue-async to 1.0.7 since it seems queue-async 1.1.0 introduces breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "^0.2.0",
     "nan": "^2.1.0",
     "node-pre-gyp": "^0.6.17",
-    "queue-async": "^1.0.7"
+    "queue-async": "1.0.7"
   },
   "bundledDependencies": [
     "node-pre-gyp"


### PR DESCRIPTION
Lock queue-async to 1.0.7 since it seems queue-async 1.1.0 breaks fontnik (can't build glyphs)
queue-async released 1.1.0 yesterday:

        '1.0.7': '2014-01-15T22:27:36.389Z'
        '1.1.0': '2016-01-20T21:24:43.832Z'
    
<code>
./bin/build-glyphs /Library/Fonts/Arial.ttf ./tmp/ && ls ./tmp | wc -l
</code>    
yields 0, while by locking to queue-async 1.0.7:

<code>    
./bin/build-glyphs /Library/Fonts/Arial.ttf ./tmp/ && ls ./tmp | wc -l
</code>

we get the correct result: 256.