### PR TITLE
Fix queue never getting emptied starting with queue-async 1.1.0 because the queue is incorrectly getting initialized with a parallelism of NaN

### DIFF
--- a/bin/build-glyphs
+++ b/bin/build-glyphs
@@ -22,7 +22,7 @@ if (!fs.existsSync(dir)) {
     process.exit(1);
 }
 
-var q = queue(Math.max(4, require('os').cpus()));
+var q = queue(Math.max(4, require('os').cpus().length));
 var queue = [];
 for (var i = 0; i < 65536; (i = i + 256)) {
     q.defer(writeGlyphs, {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "^0.2.0",
     "nan": "^2.1.0",
     "node-pre-gyp": "^0.6.17",
-    "queue-async": "1.0.7"
+    "queue-async": "^1.0.7"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "^0.2.0",
     "nan": "^2.1.0",
     "node-pre-gyp": "^0.6.17",
-    "queue-async": "^1.0.7"
+    "queue-async": "1.0.7"
   },
   "bundledDependencies": [
     "node-pre-gyp"


### PR DESCRIPTION
See https://github.com/mbostock/queue/issues/44 for the full explanation. Thanks to @mbostock for looking into it.