### PR TITLE
Publish Node.js v6.x LTS binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 # Linux
   - os: linux
     compiler: clang
-    env: CXX=clang++-3.5 NODE_VERSION=5
+    env: CXX=clang++-3.5 NODE_VERSION=6
     sudo: false
   - os: linux
     compiler: clang
@@ -27,7 +27,7 @@ matrix:
   - os: osx
     osx_image: xcode7
     compiler: clang
-    env: NODE_VERSION=5
+    env: NODE_VERSION=6
   - os: osx
     osx_image: xcode7
     compiler: clang

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The approach this library takes is to parse and rasterize the font with Freetype
 By default, installs binaries. On these platforms no external dependencies are needed.
 
 - 64 bit OS X or 64 bit Linux
-- Node.js v0.10.x, v0.12.x, v4.x or v5.x
+- Node.js v0.10.x, v0.12.x, v4.x or v6.x
 
 Just run:
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,10 @@ However, other platforms will fall back to a source compile: see [building from 
 
 ## Building from source
 
-Make sure you have `boost`, `freetype`, and `protobuf` installed. With [Homebrew](http://brew.sh/), you can
-type `brew install boost --c++11 freetype protobuf --c++11`. The Makefile uses `pkg-config` to find these
-libraries and links dynamically to them, so make sure that `pkg-config` can find
-them.
-
 ```
 npm install --build-from-source
 ```
+Building from source should automatically install `boost`, `freetype` and `protobuf` locally using [mason](https://github.com/mapbox/mason). These dependencies can be installed manually by running `./scripts/install_mason.sh`.
 
 ## Background reading
 - [Drawing Text with Signed Distance Fields in Mapbox GL](https://www.mapbox.com/blog/text-signed-distance-fields/)

--- a/bin/build-glyphs
+++ b/bin/build-glyphs
@@ -7,10 +7,10 @@ var queue = require('queue-async');
 
 if (process.argv.length !== 4) {
     console.log('Usage:');
-    console.log('  build-glyphs <fontstack> <output dir>');
+    console.log('  build-glyphs <fontstack path> <output dir>');
     console.log('');
     console.log('Example:');
-    console.log('  build-glyphs "Open Sans Regular" glyphs/');
+    console.log('  build-glyphs ./fonts/open-sans/OpenSans-Regular.ttf ./glyphs');
     process.exit(1);
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,10 @@ set -o pipefail
 
 source ./scripts/install_mason.sh
 
+node --version
+npm --version
+which node
+
 if [[ ${COVERAGE} == true ]]; then
   npm install --build-from-source --debug --clang;
 else

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -21,6 +21,3 @@ set +u
 source ./__nvm/nvm.sh
 nvm install ${NODE_VERSION}
 nvm use ${NODE_VERSION}
-node --version
-npm --version
-which node


### PR DESCRIPTION
Updates instructions for building from source and clarifies example in `build-glyphs` too.

Fixes #114 
Refs https://github.com/mapbox/node-fontnik/issues/111#issuecomment-254833027

/cc @jingsam @xingdavis