### PR TITLE
npm slimfast

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+.clang*
+.mason
+.toolchain
+bench
+build
+fonts
+lib
+mason_packages
+node_modules
+scripts
+test
+README.md
+CHANGELOG.md
+LICENSE.txt

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,12 @@ mason_packages
 node_modules
 scripts
 test
-README.md
-CHANGELOG.md
 LICENSE.txt
+cloudformation
+.travis.yml
+.gitmodules
+local.env
+*.tgz
+DEV.md
+CODE_OF_CONDUCT.md
+API.md

--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ fonts
 lib
 mason_packages
 node_modules
-scripts
 test
 LICENSE.txt
 cloudformation

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 # We set 'script' here to an empty array to prevent this section from automatically running 'npm test'
 # The reason we do this is mentioned above in the comment about the 'before_script' stage.
 # For reference, the default travis behavior which we override comes from https://github.com/travis-ci/travis-build/blob/e5a45cbf49e0d9e27398e76e5f25dd7706feb6aa/lib/travis/build/script/node_js.rb#L62-L69.
-script: []
+script:
 
 # the matrix allows you to specify different operating systems and environments to
 # run your tests and build binaries

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ matrix:
         - unset LD_PRELOAD
         # after successful tests, publish binaries if specified in commit message
         - ./scripts/publish.sh --toolset=${TOOLSET:-} --debug=$([ "${BUILDTYPE}" == 'debug' ] && echo "true" || echo "false")
-      script: []
+      script:
     # g++ build (default builds all use clang++)
     - os: linux
       env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
         - unset LD_PRELOAD
         # after successful tests, publish binaries if specified in commit message
         - ./scripts/publish.sh --toolset=${TOOLSET:-} --debug=$([ "${BUILDTYPE}" == 'debug' ] && echo "true" || echo "false")
+      script: []
     # g++ build (default builds all use clang++)
     - os: linux
       env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,7 @@ matrix:
         # after successful tests, publish binaries if specified in commit message
         - ./scripts/publish.sh --toolset=${TOOLSET:-} --debug=$([ "${BUILDTYPE}" == 'debug' ] && echo "true" || echo "false")
       script:
+        - true
     # g++ build (default builds all use clang++)
     - os: linux
       env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6"

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ testpack:
 	npm pack
 
 testpacked: testpack
-		rm -rf /tmp/package
-		tar -xf *tgz --directory=/tmp/
-		du -h -d 0 /tmp/package
-		cp -r test /tmp/package/
-		cp -r fonts /tmp/package/
-		ln -s `pwd`/mason_packages /tmp/package/mason_packages
-		(cd /tmp/package && make && make test)
+	rm -rf /tmp/package
+	tar -xf *tgz --directory=/tmp/
+	du -h -d 0 /tmp/package
+	cp -r test /tmp/package/
+	cp -r fonts /tmp/package/
+	ln -s `pwd`/mason_packages /tmp/package/mason_packages
+	(cd /tmp/package && make && make test)

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,16 @@ test:
 	npm test
 
 .PHONY: test docs
+
+testpack:
+	rm -f ./*tgz
+	npm pack
+
+testpacked: testpack
+		rm -rf /tmp/package
+		tar -xf *tgz --directory=/tmp/
+		du -h -d 0 /tmp/package
+		cp -r test /tmp/package/
+		cp -r fonts /tmp/package/
+		ln -s `pwd`/mason_packages /tmp/package/mason_packages
+		(cd /tmp/package && make && make test)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontnik",
-  "version": "0.5.1",
+  "version": "0.5.2-0",
   "description": "A library that delivers a range of glyphs rendered as SDFs (signed distance fields) in a protobuf.",
   "keywords": [
     "font",


### PR DESCRIPTION
- adds an .npmignore file to keep downstream node_modules directories small and efficient. 
- fixes a travis regression in 6567f1a
- adds and an empty `script: []` to prevent `npm test` running twice

--- 

npm pack difference: 

before
```
npm notice package size:  2.5 MB                                  
npm notice unpacked size: 4.7 MB 
```

after 
```
npm notice package size:  15.4 kB                                 
npm notice unpacked size: 48.2 kB           
```
