### PR TITLE
node-pre-gyp v0.12.0, brings needle v2.4.2. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^7.1.1",
     "minimist": "^0.2.0",
     "nan": "~2.10.0",
-    "node-pre-gyp": "~0.10.0",
+    "node-pre-gyp": "^0.12.0",
     "queue-async": "^1.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
allows for more consistent downstream installs. see https://github.com/tomas/needle/issues/261 for details. 