### PR TITLE
Fix coverage job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,6 +145,9 @@ matrix:
         - which llvm-cov
         - pip install --user codecov
         - codecov --gcov-exec "llvm-cov gcov"
+      # avoid double-run of npm test
+      script:
+        - true
     # Clang format build
     - os: linux
       # can be generic since we don't need nodejs to run formatting

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,9 +143,8 @@ matrix:
         - mason install llvm-cov ${MASON_LLVM_RELEASE}
         - mason link llvm-cov ${MASON_LLVM_RELEASE}
         - which llvm-cov
-        - curl -S -f https://codecov.io/bash -o codecov
-        - chmod +x codecov
-        - ./codecov -x "llvm-cov gcov" -Z
+        - pip install codecov
+        - codecov --gcov-exec "llvm-cov gcov"
     # Clang format build
     - os: linux
       # can be generic since we don't need nodejs to run formatting

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ matrix:
         - mason install llvm-cov ${MASON_LLVM_RELEASE}
         - mason link llvm-cov ${MASON_LLVM_RELEASE}
         - which llvm-cov
-        - pip install codecov
+        - pip install --user codecov
         - codecov --gcov-exec "llvm-cov gcov"
     # Clang format build
     - os: linux


### PR DESCRIPTION
This dodges a problem on travis https://github.com/travis-ci/travis-ci/issues/4862. The problem is that the codecov bash tool uses `find` which fails due to the way that travis sets up PATH. Instead of trying to edit the PATH variable, I learned that we can move to the python-based `codecov` CLI as it does not suffer from the same problem.
