### PR TITLE
Port to protozero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@ export WERROR ?= false
 
 default: release
 
-node_modules:
+./node_modules/.bin/node-pre-gyp:
 	# install deps but for now ignore our own install script
 	# so that we can run it directly in either debug or release
 	npm install --ignore-scripts
 
-release: node_modules
+release: ./node_modules/.bin/node-pre-gyp
 	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
 	@echo "run 'make clean' for full rebuild"
 
-debug: node_modules
+debug: ./node_modules/.bin/node-pre-gyp
 	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
 	@echo "run 'make clean' for full rebuild"
 
@@ -46,7 +46,7 @@ distclean: clean
 	rm -rf .toolchain
 	rm -f local.env
 
-xcode: node_modules
+xcode: ./node_modules/.bin/node-pre-gyp
 	./node_modules/.bin/node-pre-gyp configure -- -f xcode
 
 	@# If you need more targets, e.g. to run other npm scripts, duplicate the last line and change NPM_ARGUMENT

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,8 +9,7 @@
       'system_includes': [
         "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
         "-isystem <(module_root_dir)/mason_packages/.link/include/",
-        "-isystem <(module_root_dir)/mason_packages/.link/include/freetype2",
-        '-isystem <(SHARED_INTERMEDIATE_DIR)'
+        "-isystem <(module_root_dir)/mason_packages/.link/include/freetype2"
       ],
       # Flags we pass to the compiler to ensure the compiler
       # warns us about potentially buggy or dangerous code
@@ -54,31 +53,11 @@
       ]
     },
     {
-      'target_name': 'action_before_build2',
-      'type': 'none',
-      'dependencies': [
-        'action_before_build'
-      ],
-      'hard_dependency': 1,
-      'actions': [
-        {
-          'action_name': 'run_protoc_glyphs',
-          'inputs': [
-            './proto/glyphs.proto'
-          ],
-          'outputs': [
-            "<(SHARED_INTERMEDIATE_DIR)/glyphs.pb.cc"
-          ],
-          'action': ['./mason_packages/.link/bin/protoc','-Iproto/','--cpp_out=<(SHARED_INTERMEDIATE_DIR)/','./proto/glyphs.proto']
-        }
-      ]
-    },
-    {
       # module_name and module_path are both variables passed by node-pre-gyp from package.json
       'target_name': '<(module_name)', # sets the name of the binary file
       'product_dir': '<(module_path)', # controls where the node binary file gets copied to (./lib/binding/module.node)
       'type': 'loadable_module',
-      'dependencies': [ 'action_before_build2' ],
+      'dependencies': [ 'action_before_build' ],
       # "make" only watches files specified here, and will sometimes cache these files after the first compile.
       # This cache can sometimes cause confusing errors when removing/renaming/adding new files.
       # Running "make clean" helps to prevent this "mysterious error by cache" scenario
@@ -86,13 +65,11 @@
       # See: https://github.com/mapbox/node-cpp-skel/pull/44#discussion_r122050205
       'sources': [
         'src/node_fontnik.cpp',
-        'src/glyphs.cpp',
-        '<(SHARED_INTERMEDIATE_DIR)/glyphs.pb.cc'
+        'src/glyphs.cpp'
       ],
       "link_settings": {
         "libraries": [
-         "-lfreetype",
-         "-lprotobuf-lite"
+         "-lfreetype"
          ],
         "library_dirs": [
           "<(module_root_dir)/mason_packages/.link/lib"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -13,10 +13,6 @@ function install() {
 source local.env
 
 install boost 1.63.0
-#link boost 1.63.0 # is linking needed?
 install freetype 2.7.1
-#link freetype 2.7.1
-install protobuf 3.2.0
-#link protobuf 3.2.0
+install protozero 1.6.8
 install sdf-glyph-foundry 0.1.1
-#link sdf-glyph-foundry 0.1.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-eeba3b5}"
+export MASON_RELEASE="${MASON_RELEASE:-master}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -309,11 +309,11 @@ void RangeAsync(uv_work_t* req) {
             if (ft_face->family_name) {
                 protozero::pbf_writer fontstack_writer{pbf_writer, 1};
                 if (ft_face->style_name) {
-                    fontstack_writer.add_string(1,std::string(ft_face->family_name) + " " + std::string(ft_face->style_name));
+                    fontstack_writer.add_string(1, std::string(ft_face->family_name) + " " + std::string(ft_face->style_name));
                 } else {
-                    fontstack_writer.add_string(1,std::string(ft_face->family_name));
+                    fontstack_writer.add_string(1, std::string(ft_face->family_name));
                 }
-                fontstack_writer.add_string(2,std::to_string(baton->start) + "-" + std::to_string(baton->end));
+                fontstack_writer.add_string(2, std::to_string(baton->start) + "-" + std::to_string(baton->end));
 
                 const double scale_factor = 1.0;
 
@@ -340,17 +340,17 @@ void RangeAsync(uv_work_t* req) {
                     if (char_code > std::numeric_limits<FT_ULong>::max()) {
                         throw std::runtime_error("Invalid value for char_code: too large");
                     } else {
-                        glyph_writer.add_uint32(1,static_cast<std::uint32_t>(char_code));
+                        glyph_writer.add_uint32(1, static_cast<std::uint32_t>(char_code));
                     }
 
                     if (glyph.width > 0) {
-                        glyph_writer.add_bytes(2,glyph.bitmap); 
+                        glyph_writer.add_bytes(2, glyph.bitmap);
                     }
 
                     // direct type conversions, no need for checking or casting
-                    glyph_writer.add_uint32(3,glyph.width);
-                    glyph_writer.add_uint32(4,glyph.width);
-                    glyph_writer.add_sint32(5,glyph.width);
+                    glyph_writer.add_uint32(3, glyph.width);
+                    glyph_writer.add_uint32(4, glyph.width);
+                    glyph_writer.add_sint32(5, glyph.width);
 
                     // conversions requiring checks, for safety and correctness
 
@@ -359,16 +359,15 @@ void RangeAsync(uv_work_t* req) {
                     if (top < std::numeric_limits<std::int32_t>::min() || top > std::numeric_limits<std::int32_t>::max()) {
                         throw std::runtime_error("Invalid value for glyph.top-glyph.ascender");
                     } else {
-                        glyph_writer.add_sint32(6,static_cast<std::int32_t>(top));
+                        glyph_writer.add_sint32(6, static_cast<std::int32_t>(top));
                     }
 
                     // double to uint
                     if (glyph.advance < std::numeric_limits<std::uint32_t>::min() || glyph.advance > std::numeric_limits<std::uint32_t>::max()) {
                         throw std::runtime_error("Invalid value for glyph.top-glyph.ascender");
                     } else {
-                        glyph_writer.add_uint32(7,static_cast<std::uint32_t>(glyph.advance));                      
+                        glyph_writer.add_uint32(7, static_cast<std::uint32_t>(glyph.advance));
                     }
-
                 }
             } else {
                 baton->error_name = std::string("font does not have family_name");

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -349,8 +349,8 @@ void RangeAsync(uv_work_t* req) {
 
                     // direct type conversions, no need for checking or casting
                     glyph_writer.add_uint32(3, glyph.width);
-                    glyph_writer.add_uint32(4, glyph.width);
-                    glyph_writer.add_sint32(5, glyph.width);
+                    glyph_writer.add_uint32(4, glyph.height);
+                    glyph_writer.add_sint32(5, glyph.left);
 
                     // conversions requiring checks, for safety and correctness
 

--- a/src/glyphs.hpp
+++ b/src/glyphs.hpp
@@ -1,7 +1,6 @@
 #ifndef NODE_FONTNIK_GLYPHS_HPP
 #define NODE_FONTNIK_GLYPHS_HPP
 
-#include "glyphs.pb.h"
 #include <nan.h>
 
 namespace node_fontnik {


### PR DESCRIPTION
This changes the code to use protozero instead of the google libprotobuf library.

More context at https://github.com/mapbox/node-fontnik/issues/143.

I needed this SDF generation for a different project where I did not want to not use the libprotobuf library, so I worked on this first here to ensure the tests were passing. 

TODO:

 - [ ] Code review
 - [ ] Potentially use pbf_builder with strongly typed enums that are clearly named instead of using integers (which make mistakes easier): https://github.com/mapbox/protozero/blob/master/doc/tutorial.md#writing-protobuf-encoded-messages-using-pbf_builder

/cc @mapbox/map-design-team @mapbox/maps-api @mapbox/api-gl 