### PR TITLE
Add "Local testing" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run tests with
 npm test
 ```
 
-If you make any changes to the C++ files in the `src/` directory, you'll need to recompile the node bindings (`fontnike.node`) before testing locally:
+If you make any changes to the C++ files in the `src/` directory, you'll need to recompile the node bindings (`fontnik.node`) before testing locally:
 
 ```
 make

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ npm install --build-from-source
 ```
 Building from source should automatically install `boost`, `freetype` and `protobuf` locally using [mason](https://github.com/mapbox/mason). These dependencies can be installed manually by running `./scripts/install_deps.sh`.
 
+## Local testing
+
+Run tests with
+
+```
+npm test
+```
+
+If you make any changes to the C++ files in the `src/` directory, you'll need to recompile the node bindings (`fontnike.node`) before testing locally:
+
+```
+make
+```
+
+See the `Makefile` for additional tasks you can run, such as `make coverage`.
+
 ## Background reading
 - [Drawing Text with Signed Distance Fields in Mapbox GL](https://www.mapbox.com/blog/text-signed-distance-fields/)
 - [State of Text Rendering](http://behdad.org/text/)


### PR DESCRIPTION
Add section about testing locally, which includes a note about needing to run `make` to generate node bindings.