### PR TITLE
node12: fixes warning in build, allow compile in macOS environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
-OS := $(uname | tr A-Z a-z)
+OS=$(shell uname | tr A-Z a-z)
 
 # Whether to turn compiler warnings into errors
 export WERROR ?= false
@@ -12,21 +12,21 @@ default: release
 	npm install --ignore-scripts
 
 release: ./node_modules/.bin/node-pre-gyp
-	ifeq($(OS),darwin)
-		./scripts/setup.sh --config local.env
-		. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
-	else
-		V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
-	endif
+ifeq ($(OS),darwin)
+	./scripts/setup.sh --config local.env
+	. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+else
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+endif
 	@echo "run 'make clean' for full rebuild"
 
 debug: ./node_modules/.bin/node-pre-gyp
-	ifeq($(OS),darwin)
-		./scripts/setup.sh --config local.env
-		. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
-	else
-		V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
-	endif
+ifeq ($(OS),darwin)
+	./scripts/setup.sh --config local.env
+	. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
+else
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
+endif
 	@echo "run 'make clean' for full rebuild"
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ default: release
 	npm install --ignore-scripts
 
 release: ./node_modules/.bin/node-pre-gyp
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+	./scripts/setup.sh --config local.env
+	. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
 	@echo "run 'make clean' for full rebuild"
 
 debug: ./node_modules/.bin/node-pre-gyp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
+OS := $(uname | tr A-Z a-z)
 
 # Whether to turn compiler warnings into errors
 export WERROR ?= false
@@ -11,12 +12,21 @@ default: release
 	npm install --ignore-scripts
 
 release: ./node_modules/.bin/node-pre-gyp
-	./scripts/setup.sh --config local.env
-	. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+	ifeq($(OS),darwin)
+		./scripts/setup.sh --config local.env
+		. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+	else
+		V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
+	endif
 	@echo "run 'make clean' for full rebuild"
 
 debug: ./node_modules/.bin/node-pre-gyp
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
+	ifeq($(OS),darwin)
+		./scripts/setup.sh --config local.env
+		. local.env; V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
+	else
+		V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
+	endif
 	@echo "run 'make clean' for full rebuild"
 
 coverage:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "font-inspect": "./bin/font-inspect"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build=true",
+    "install": "./scripts/setup.sh --config local.env; . local.env; node-pre-gyp install --fallback-to-build=true",
     "test": "./node_modules/.bin/tape test/**/*.test.js",
     "prepublishOnly": "npm ls"
   },

--- a/src/glyphs.cpp
+++ b/src/glyphs.cpp
@@ -572,7 +572,7 @@ void RangeAsync(uv_work_t* req) {
                     // direct type conversions, no need for checking or casting
                     glyph_writer.add_uint32(3, glyph.width);
                     glyph_writer.add_uint32(4, glyph.width);
-                    glyph_writer.add_sint32(5, glyph.width);
+                    glyph_writer.add_sint32(5, static_cast<int32_t>(glyph.width));
 
                     // conversions requiring checks, for safety and correctness
 


### PR DESCRIPTION
If I do following, original branch just work in macOS.

```
./scripts/setup.sh --config local.env
source local.env
make
```

travis-ci run setup.sh and source command in install task so that may work.
but only `make` command can't build.
`source local.env` run in [node-pre-gpy's action](https://github.com/mapbox/node-fontnik/blob/master/binding.gyp#L47) but in macOS can't export any environment.
So, `make` command and `npm install` from other project missing the compiler (mason's clang++).
I just fix this issuees for Makefile and package.json.

Also `npm install` from other depend project, clang++'s warning become error, so I fixed warning message.

Now, I can do install from other project.

/cc @springmeyer 